### PR TITLE
fix: respect OAuth2 specification

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,10 +212,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("clientSecret", a.clientSecret),
 			slog.String("url", a.apiManagerURL),
 			slog.String("method", "POST"),
-			slog.Any("headers", map[string]string{
-				"Content-Type":  "application/json",
-				"Authorization": "Basic " + auth,
-			}),
+			slog.Any("headers", req.Header),
 			slog.Int("statusCode", resp.StatusCode),
 			slog.String("receivedBody", string(body)),
 		)
@@ -235,10 +232,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("clientSecret", a.clientSecret),
 			slog.String("url", a.apiManagerURL),
 			slog.String("method", "POST"),
-			slog.Any("headers", map[string]string{
-				"Content-Type":  "application/json",
-				"Authorization": "Basic " + auth,
-			}),
+			slog.Any("headers", req.Header),
 			slog.Int("statusCode", resp.StatusCode),
 			slog.String("receivedBody", string(body)),
 			slog.String("error", err.Error()),
@@ -256,10 +250,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("clientSecret", a.clientSecret),
 			slog.String("url", a.apiManagerURL),
 			slog.String("method", "POST"),
-			slog.Any("headers", map[string]string{
-				"Content-Type":  "application/json",
-				"Authorization": "Basic " + auth,
-			}),
+			slog.Any("headers", req.Header),
 			slog.Int("statusCode", resp.StatusCode),
 			slog.String("receivedBody", string(body)),
 		)

--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ type APIManagerResponse struct {
 
 // New - create a new instance of APIManagerPlugin
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
-
 	// logger instance
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
@@ -194,6 +193,25 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 	if err := json.Unmarshal(body, &apiResp); err != nil {
 		return "", err
 	}
+
+	a.logger.Info("getting an access token from remote API manager",
+		slog.String("plugin", "traefik-api-manager"),
+		slog.String("username", a.username),
+		slog.String("password", a.password),
+		slog.String("grantType", a.grantType),
+		slog.String("scope", a.scope),
+		slog.String("clientID", a.clientID),
+		slog.String("clientSecret", a.clientSecret),
+		slog.String("url", a.apiManagerURL),
+		slog.String("method", "POST"),
+		slog.String("body", string(requestBody)),
+		slog.Any("headers", map[string]string{
+			"Content-Type":  "application/json",
+			"Authorization": "Basic " + auth,
+		}),
+		slog.String("receivedBody", string(body)),
+		slog.String("parsedAccessToken", apiResp.AccessToken),
+	)
 
 	return apiResp.AccessToken, nil
 }


### PR DESCRIPTION
I encountered a problem using this plugin with an Identity Provider that complies with the OAuth2 specification.

- add environment variable `TRAEFIK_API_MANAGER_PLUGIN_LOG_LEVEL` to set log level
- add some DEBUG logs in the OAuth2 access token retrival function `getOAuth2AccessToken` (_warning, secrets `username`, `password`, `grantType`, `scope`, `clientId`, `clientSecret` are shown in those debug logs_)
> By default, traefik plugins only logs with level >= `INFO`, so those logs won't be written, unless `TRAEFIK_API_MANAGER_PLUGIN_LOG_LEVEL` environment variable is set to `DEBUG`
- return an error when the remote `token` endpoint return an error (_the traefik-apimanager-plugin:v1.0.0 was trying to parse a JSON error message from the remote IdP and return an empty `apiResp.AccessToken`_)
- return an error when parsed `access_token` is an empty string
- update the body payload and the header `Content-Type` when retrieving an access token in order to match the [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2)