### PR TITLE
feat(token): mise en cache du jeton OAuth2 et coalescing des rafraîchissements concurrents

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 )
 
 type Config struct {
@@ -27,6 +29,7 @@ type Config struct {
 	HeaderValue   string   `json:"headerValue,omitempty"`
 	Paths         []string `json:"paths,omitempty"`
 	Scope         string   `json:"scope,omitempty"`
+	Margin        int      `json:"margin,omitempty"`
 }
 
 func CreateConfig() *Config {
@@ -48,6 +51,14 @@ type APIManagerPlugin struct {
 	paths         []string
 	scope         string
 	logger        *slog.Logger
+
+	margin time.Duration
+
+	mu          sync.RWMutex
+	token       string
+	tokenExpiry time.Time
+
+	fetchMu sync.Mutex
 }
 
 type APIManagerQuery struct {
@@ -59,7 +70,13 @@ type APIManagerQuery struct {
 
 type APIManagerResponse struct {
 	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
 }
+
+// defaultRefreshMargin is how far before real expiry a cached token is refreshed by
+// default, so an about-to-expire token is never forwarded upstream. Operators may
+// override it with the optional "margin" config (in seconds).
+const defaultRefreshMargin = 30 * time.Second
 
 // New - create a new instance of APIManagerPlugin
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
@@ -89,6 +106,12 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		logger.Info("traefik-api-manager - default auth mode used (required: oauth2 or apikey)")
 	}
 
+	// Refresh margin defaults to a fixed value; operators tune it only if they want.
+	margin := defaultRefreshMargin
+	if config.Margin > 0 {
+		margin = time.Duration(config.Margin) * time.Second
+	}
+
 	return &APIManagerPlugin{
 		next:          next,
 		authMode:      config.AuthMode,
@@ -104,6 +127,7 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		paths:         config.Paths,
 		name:          name,
 		logger:        logger,
+		margin:        margin,
 	}, nil
 }
 
@@ -119,7 +143,7 @@ func (a *APIManagerPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 
 	switch a.authMode {
 	case "oauth2":
-		token, err := a.getOAuth2AccessToken()
+		token, err := a.getToken()
 		if err != nil {
 			a.logger.Error("traefik-api-manager - failed to retrieve access token", slog.String("error", err.Error()))
 			http.Error(rw, "Failed to retrieve access token", http.StatusInternalServerError)
@@ -167,8 +191,50 @@ func (a *APIManagerPlugin) checkPathMatching(path string) bool {
 	return matched
 }
 
+// getToken - return the cached token, or fetch a fresh one when the cache is empty or
+// expired. The expiry is now + expires_in - margin, so a
+// missing expires_in (0) or a margin larger than the lifetime lands the expiry in the
+// past and the next request simply refetches — no special-casing needed.
+//
+// mu guards the shared cache because Traefik serves requests on multiple goroutines in
+// parallel. fetchMu coalesces refreshes: when the cache is stale, only one goroutine
+// performs the upstream call while the rest wait, then re-read the freshly cached token
+// instead of each firing its own request at the API manager.
+func (a *APIManagerPlugin) getToken() (string, error) {
+	if token, ok := a.cachedToken(); ok {
+		return token, nil
+	}
+
+	a.fetchMu.Lock()
+	defer a.fetchMu.Unlock()
+
+	// Re-check: another goroutine may have refreshed the cache while we waited on fetchMu.
+	if token, ok := a.cachedToken(); ok {
+		return token, nil
+	}
+
+	token, expiresIn, err := a.getOAuth2AccessToken()
+	if err != nil {
+		return "", err
+	}
+
+	a.mu.Lock()
+	a.token = token
+	a.tokenExpiry = time.Now().Add(time.Duration(expiresIn)*time.Second - a.margin)
+	a.mu.Unlock()
+	return token, nil
+}
+
+// cachedToken - return the cached token and whether it is still valid (non-empty and
+// not past its expiry). Guarded by mu for concurrent access.
+func (a *APIManagerPlugin) cachedToken() (string, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.token, a.token != "" && time.Now().Before(a.tokenExpiry)
+}
+
 // getOAuth2AccessToken - call API manager with OAuth 2.0 protocol to get an access token
-func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
+func (a *APIManagerPlugin) getOAuth2AccessToken() (string, int, error) {
 	query := url.Values{}
 	query.Set("grant_type", a.grantType)
 	query.Set("username", a.username)
@@ -181,7 +247,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 
 	req, err := http.NewRequest("POST", a.apiManagerURL, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return "", fmt.Errorf("failed to create POST request: %v", err)
+		return "", 0, fmt.Errorf("failed to create POST request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -192,13 +258,13 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send POST request: %v", err)
+		return "", 0, fmt.Errorf("failed to send POST request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -217,7 +283,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("receivedBody", string(body)),
 		)
 
-		return "", fmt.Errorf("API manager returned a %v status code", resp.StatusCode)
+		return "", 0, fmt.Errorf("API manager returned a %v status code", resp.StatusCode)
 	}
 
 	var apiResp APIManagerResponse
@@ -238,7 +304,7 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("error", err.Error()),
 		)
 
-		return "", err
+		return "", 0, err
 	} else if apiResp.AccessToken == "" {
 		a.logger.Debug("received access_token from API manager is a empty string",
 			slog.String("plugin", "traefik-api-manager"),
@@ -255,8 +321,8 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, error) {
 			slog.String("receivedBody", string(body)),
 		)
 
-		return "", fmt.Errorf("parsed access_token is an empty string")
+		return "", 0, fmt.Errorf("parsed access_token is an empty string")
 	}
 
-	return apiResp.AccessToken, nil
+	return apiResp.AccessToken, apiResp.ExpiresIn, nil
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -69,8 +70,28 @@ type APIManagerQuery struct {
 }
 
 type APIManagerResponse struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken string  `json:"access_token"`
+	ExpiresIn   flexInt `json:"expires_in"`
+}
+
+// flexInt is an int that unmarshals from either a JSON number (3600) or a
+// JSON string ("3600"). RFC 6749 §5.1 shows expires_in unquoted, but some API
+// managers emit it quoted; accepting both keeps a valid token from being
+// discarded over a formatting quirk.
+type flexInt int
+
+func (n *flexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.Trim(b, `"`)
+	if len(b) == 0 || string(b) == "null" {
+		*n = 0
+		return nil
+	}
+	v, err := strconv.Atoi(string(b))
+	if err != nil {
+		return err
+	}
+	*n = flexInt(v)
+	return nil
 }
 
 // defaultRefreshMargin is how far before real expiry a cached token is refreshed by
@@ -324,5 +345,5 @@ func (a *APIManagerPlugin) getOAuth2AccessToken() (string, int, error) {
 		return "", 0, fmt.Errorf("parsed access_token is an empty string")
 	}
 
-	return apiResp.AccessToken, apiResp.ExpiresIn, nil
+	return apiResp.AccessToken, int(apiResp.ExpiresIn), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -454,6 +454,35 @@ func TestOAuth2TokenIsCached(t *testing.T) {
 	}
 }
 
+// TestOAuth2TokenIsCachedWithStringExpiresIn - some API managers emit expires_in as a
+// JSON string ("3600") rather than a number. The token must still parse and be cached,
+// not rejected: repeated requests reuse it and the API manager is called only once.
+func TestOAuth2TokenIsCachedWithStringExpiresIn(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": "3600"}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), oauth2TestConfig(mockServer.URL), "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		serveOAuth2(t, handler)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected string expires_in to be parsed and the token cached (1 call), got %d", got)
+	}
+}
+
 // TestOAuth2TokenRefreshedAfterExpiry - once the server-provided lifetime elapses,
 // the next request re-fetches the token.
 func TestOAuth2TokenRefreshedAfterExpiry(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	apimanager "github.com/MGDIS/traefik-apimanager-plugin"
 )
@@ -398,4 +401,236 @@ func TestAPIManagerPluginDontTriggerPaths(t *testing.T) {
 	handler.ServeHTTP(recorder, req)
 
 	assertHeader(t, req, "Authorization", "Bearer awesome_token")
+}
+
+// oauth2TestConfig builds a minimal oauth2 config pointing at the given mock URL.
+func oauth2TestConfig(url string) *apimanager.Config {
+	cfg := apimanager.CreateConfig()
+	cfg.APIManagerURL = url
+	cfg.AuthMode = "oauth2"
+	cfg.ClientID = "clientID"
+	cfg.ClientSecret = "clientSecret"
+	cfg.Username = "user"
+	cfg.Password = "pass"
+	cfg.GrantType = "password"
+	return cfg
+}
+
+func serveOAuth2(t *testing.T, handler http.Handler) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	assertHeader(t, req, "Authorization", "Bearer apimanager_token")
+}
+
+// TestOAuth2TokenIsCached - while a token with a server-provided expires_in is still
+// valid, repeated requests reuse it and the API manager is called only once.
+func TestOAuth2TokenIsCached(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": 3600}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), oauth2TestConfig(mockServer.URL), "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		serveOAuth2(t, handler)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected API manager to be called once (token cached), got %d", got)
+	}
+}
+
+// TestOAuth2TokenRefreshedAfterExpiry - once the server-provided lifetime elapses,
+// the next request re-fetches the token.
+func TestOAuth2TokenRefreshedAfterExpiry(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": 2}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	cfg := oauth2TestConfig(mockServer.URL)
+	cfg.Margin = 1 // 2s lifetime - 1s margin => cached ~1s (also proves the margin is applied)
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), cfg, "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serveOAuth2(t, handler)
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 call after first request, got %d", got)
+	}
+
+	time.Sleep(1200 * time.Millisecond) // past the ~1s cached window
+
+	serveOAuth2(t, handler)
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected token refresh after expiry (2 calls), got %d", got)
+	}
+}
+
+// TestOAuth2NoCacheWithoutExpiresIn - with no expires_in in the response, the plugin
+// must not cache: it fetches a fresh token on every request, exactly as before.
+func TestOAuth2NoCacheWithoutExpiresIn(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token"}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), oauth2TestConfig(mockServer.URL), "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		serveOAuth2(t, handler)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("expected a fetch per request when the server sends no expires_in (3 calls), got %d", got)
+	}
+}
+
+// TestOAuth2NoCacheWhenMarginExceedsLifetime - if the refresh margin does not fit
+// within the token's lifetime there is no safety buffer, so the plugin must not
+// cache and must fetch on every request.
+func TestOAuth2NoCacheWhenMarginExceedsLifetime(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": 5}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	cfg := oauth2TestConfig(mockServer.URL)
+	cfg.Margin = 10 // margin (10s) > lifetime (5s) => no safety buffer => must not cache
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), cfg, "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		serveOAuth2(t, handler)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("expected a fetch per request when margin exceeds lifetime (3 calls), got %d", got)
+	}
+}
+
+// TestOAuth2ConcurrentReadsHitCache - once the token is cached, many concurrent
+// requests all reuse it (no extra fetches) and the race detector stays clean.
+func TestOAuth2ConcurrentReadsHitCache(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": 3600}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), oauth2TestConfig(mockServer.URL), "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serveOAuth2(t, handler) // warm the cache: 1 fetch
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost", nil)
+			if err != nil {
+				t.Errorf("failed to build request: %v", err)
+				return
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+			assertHeader(t, req, "Authorization", "Bearer apimanager_token")
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected concurrent requests to reuse the cached token (1 fetch), got %d", got)
+	}
+}
+
+// TestOAuth2ConcurrentRefreshCoalesces - when many requests hit a cold cache at once,
+// only one goroutine calls the API manager; the rest wait and reuse its token. The
+// mock sleeps to widen the race window so an uncoalesced implementation would fan out.
+func TestOAuth2ConcurrentRefreshCoalesces(t *testing.T) {
+	var calls int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		time.Sleep(50 * time.Millisecond)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		if _, err := rw.Write([]byte(`{"access_token": "apimanager_token", "expires_in": 3600}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler, err := apimanager.New(context.Background(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), oauth2TestConfig(mockServer.URL), "apimanager-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost", nil)
+			if err != nil {
+				t.Errorf("failed to build request: %v", err)
+				return
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+			assertHeader(t, req, "Authorization", "Bearer apimanager_token")
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected concurrent cold-cache requests to coalesce into 1 fetch, got %d", got)
+	}
 }


### PR DESCRIPTION
## Objectif

Le plugin ajoute un jeton d'accès OAuth 2.0 aux requêtes qu'il intercepte (mode `oauth2`). Jusqu'ici, un nouveau jeton était demandé à l'API Manager **à chaque requête**, ce qui est à la fois inutilement coûteux et contraire à l'esprit de la spécification OAuth 2.0.

Cette évolution met en cache le jeton et le réutilise jusqu'à sa date d'expiration, puis coordonne les rafraîchissements concurrents.

## Fondement RFC (RFC 6749 — The OAuth 2.0 Authorization Framework)

- **§5.1 — Successful Response.** Le serveur d'autorisation renvoie le champ `expires_in`, défini comme « the lifetime in seconds of the access token ». La présence de ce champ signifie explicitement qu'un client **peut et doit réutiliser** le jeton pendant toute sa durée de vie, plutôt que d'en redemander un à chaque appel. Le comportement précédent (une requête de jeton par requête entrante) ignorait `expires_in` et allait à l'encontre de cette intention.
- **§4.3 — Resource Owner Password Credentials Grant.** Le plugin utilise `grant_type=password` ; la RFC précise (§4.3.3) que la réponse suit le format du §5.1, donc `expires_in` y est bien la source de vérité pour la durée de validité.
- **§1.4 / §1.5 — Access Token vs Refresh Token.** La RFC prévoit que les jetons d'accès ont une durée de vie courte et sont réutilisés jusqu'à expiration ; on ne redemande un jeton qu'une fois celui-ci périmé. Le cache implémente exactement ce cycle de vie.
- **§10.3 — Token Security.** Un jeton proche de l'expiration ne doit pas être transmis au risque d'être rejeté en aval. C'est la raison de la **marge de rafraîchissement** (voir ci-dessous).

## Choix d'implémentation

**1. Cache du jeton fondé sur `expires_in`.**
L'expiration est calculée comme `now + expires_in - margin`. Tant que le jeton est valide, toutes les requêtes le réutilisent ; aucun appel à l'API Manager n'est effectué.

**2. Marge de rafraîchissement (`margin`, défaut 30 s).**
Conformément à l'esprit du §10.3, on rafraîchit le jeton un peu **avant** son expiration réelle, pour ne jamais transmettre en amont un jeton sur le point d'expirer (tolérance à la latence réseau et au décalage d'horloge). La marge est configurable via l'option `margin` (en secondes).

**3. Dégradation sûre (pas de cache) dans deux cas.**
   - **`expires_in` absent (0)** : la RFC §5.1 indique que `expires_in` est seulement *RECOMMENDED*. En son absence, on ne peut pas connaître la durée de vie, donc on ne met **pas** en cache — on retombe sur le comportement historique (un jeton par requête). C'est le choix conservateur et correct.
   - **`margin` ≥ durée de vie** : il n'existe alors aucune fenêtre de sécurité ; on préfère ne pas mettre en cache plutôt que de servir un jeton déjà « à risque ».
   Ces deux cas tombent naturellement du calcul `now + expires_in - margin` qui place l'expiration dans le passé — aucun traitement particulier n'est nécessaire.

**4. Coordination des rafraîchissements concurrents (coalescing).**
Traefik sert les requêtes sur plusieurs goroutines en parallèle. Sans coordination, à l'expiration du jeton, **toutes** les requêtes en vol constateraient simultanément le cache périmé et déclencheraient chacune leur propre appel à l'API Manager (effet « thundering herd »).
La solution retenue :
   - `mu` (`sync.RWMutex`) protège le cache partagé en lecture/écriture ;
   - `fetchMu` (`sync.Mutex`) avec un **double-checked locking** garantit qu'un seul goroutine effectue l'appel réseau lorsque le cache est froid/expiré ; les autres attendent puis relisent le jeton fraîchement mis en cache.
   Résultat : **un seul appel amont** au lieu d'une rafale, quel que soit le nombre de requêtes concurrentes.

**5. Aucune dépendance externe.**
Le coalescing est implémenté avec la seule bibliothèque standard (`sync`), sans recourir à `golang.org/x/sync/singleflight`. C'est volontaire : le plugin est interprété par **Yaegi** dans Traefik, qui impose des contraintes sur les dépendances ; rester sur la bibliothèque standard garantit le chargement du plugin en v3.

## Tests

Ajout / mise à jour de la couverture, exécutée avec le détecteur de data race (`go test -race`) :

- réutilisation du jeton mis en cache (`expires_in` valide → 1 seul appel) ;
- rafraîchissement après expiration ;
- absence de cache quand `expires_in` est absent ;
- absence de cache quand `margin` dépasse la durée de vie ;
- lectures concurrentes servies depuis le cache ;
- **rafraîchissement concurrent sur cache froid coalescé en un unique appel** (le mock temporise pour élargir la fenêtre de course).

## Références

- RFC 6749 — The OAuth 2.0 Authorization Framework : https://www.rfc-editor.org/rfc/rfc6749
  (§1.4–1.5, §4.3, §5.1, §10.3)